### PR TITLE
Added soft dependency to Castra

### DIFF
--- a/info.json
+++ b/info.json
@@ -11,7 +11,8 @@
 		"Voidcraft >= 1.4.16",
 		"? maraxsis >= 1.29.20",
 		"? tenebris-prime >= 1.3.2",
-		"? metal-and-stars >= 0.1.7"
+		"? metal-and-stars >= 0.1.7",
+		"? castra >= 0.5.4"
 	],
 	"space_travel_required": true,
 	"factorio_version": "2.0"


### PR DESCRIPTION
Without the fix I was getting this error during loading:
```
Failed to load mods: __Voidcraft__/prototypes/voidcrafting.lua:141: attempt to index field '?' (a nil value)
stack traceback:
	__Voidcraft__/prototypes/voidcrafting.lua:141: in function 'voidcraft_recipe'
	__voidcraft-planetary-compatibility__/compat/castra.lua:43: in main chunk
	[C]: in function 'require'
	__voidcraft-planetary-compatibility__/data.lua:23: in main chunk

Mods to be disabled:
• voidcraft-planetary-compatibility (0.1.9)
```

After a bit of debugging I saw it was caused by castra being loaded after voidcraft. Adding the dependency made it load